### PR TITLE
Add script to auto-rebase conflicted pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ npm run build
 - Legacy dated blog URLs are preserved for migrated writing posts.
 - The public profile and CV are kept concise and research-first rather than mirroring a full resume export.
 - In GitHub Pages settings, the source must be `GitHub Actions`. Branch-based Pages builds will try to build the Astro source tree directly and fail.
+
+## Resolving conflicted PRs
+
+When multiple open PRs are blocked by merge conflicts, run:
+
+```bash
+./scripts/resolve-pr-conflicts.sh [base-branch] [limit]
+```
+
+- `base-branch` defaults to the repository default branch.
+- `limit` defaults to `20` open PRs.
+- The script detects open PRs in the `DIRTY` merge state, rebases each PR branch onto the latest base branch, and force-pushes successful rebases.
+

--- a/scripts/resolve-pr-conflicts.sh
+++ b/scripts/resolve-pr-conflicts.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: GitHub CLI (gh) is required." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required." >&2
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: run this script inside a git repository." >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is dirty. Commit or stash changes first." >&2
+  exit 1
+fi
+
+base_branch="${1:-$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')}"
+limit="${2:-20}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "Fetching latest refs..."
+git fetch --all --prune
+
+echo "Collecting open pull requests with merge conflicts against ${base_branch}..."
+mapfile -t conflicted_prs < <(
+  gh pr list \
+    --state open \
+    --base "$base_branch" \
+    --limit "$limit" \
+    --json number,headRefName,mergeStateStatus,title \
+    | jq -r '.[] | select(.mergeStateStatus == "DIRTY") | [.number, .headRefName, .title] | @tsv'
+)
+
+if ((${#conflicted_prs[@]} == 0)); then
+  echo "No conflicting PRs found."
+  exit 0
+fi
+
+echo "Found ${#conflicted_prs[@]} conflicting PR(s). Attempting automatic rebases..."
+
+declare -a resolved_prs=()
+declare -a unresolved_prs=()
+
+for line in "${conflicted_prs[@]}"; do
+  IFS=$'\t' read -r pr_number pr_branch pr_title <<<"$line"
+
+  work_branch="resolve/pr-${pr_number}"
+  echo ""
+  echo "---"
+  echo "PR #${pr_number}: ${pr_title}"
+
+  if ! git show-ref --verify --quiet "refs/remotes/origin/${pr_branch}"; then
+    echo "⚠️  missing remote branch origin/${pr_branch}; skipping"
+    unresolved_prs+=("#${pr_number} ${pr_title}")
+    continue
+  fi
+
+  git checkout -B "$work_branch" "origin/${pr_branch}" >/dev/null 2>&1
+
+  if git rebase "origin/${base_branch}"; then
+    git push --force-with-lease origin "${work_branch}:${pr_branch}"
+    resolved_prs+=("#${pr_number} ${pr_title}")
+    echo "✅ Rebased and pushed ${pr_branch}"
+  else
+    echo "❌ Rebase failed for PR #${pr_number}; aborting rebase"
+    git rebase --abort || true
+    unresolved_prs+=("#${pr_number} ${pr_title}")
+  fi
+
+done
+
+git checkout "$current_branch" >/dev/null 2>&1
+
+echo ""
+echo "=== Summary ==="
+echo "Resolved: ${#resolved_prs[@]}"
+for item in "${resolved_prs[@]}"; do
+  echo "  - ${item}"
+done
+
+echo "Unresolved: ${#unresolved_prs[@]}"
+for item in "${unresolved_prs[@]}"; do
+  echo "  - ${item}"
+done


### PR DESCRIPTION
### Motivation

- Provide a repeatable automation to resolve batches of open PRs that are blocked by merge conflicts so maintainers can quickly restore mergeability. 
- Document the recommended workflow for resolving conflicted PRs and reduce manual rebasing work across multiple branches.

### Description

- Add `scripts/resolve-pr-conflicts.sh`, which discovers PRs in the `DIRTY` merge state via `gh pr list`, attempts to rebase each head branch onto the latest base branch, and force-pushes successful rebases back to the PR branch. 
- The script requires `gh` and `jq`, verifies a clean working tree, skips missing remote branches, and prints a resolved vs unresolved summary. 
- Add usage documentation to `README.md` under the new **Resolving conflicted PRs** section showing `./scripts/resolve-pr-conflicts.sh [base-branch] [limit]` and defaults. 

### Testing

- Ran `npm test` (Vitest) and all tests passed (`4` files, `7` tests). 
- Ran `bash -n scripts/resolve-pr-conflicts.sh` to validate the script syntax and it succeeded. 
- Executing `./scripts/resolve-pr-conflicts.sh` could not run end-to-end in this environment because the `gh` CLI is not installed, so live PR rebasing was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26bb0d8e4832caeaa4b20861585b2)